### PR TITLE
create symbolic links so as not to break GDAL

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,3 +14,10 @@ cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
 make
 make install
 make test
+
+# hack so the old 1.4.6 .so still exists
+if [ `uname` == Darwin ]; then
+    ln -s $PREFIX/lib/libkea.1.4.7.dylib $PREFIX/lib/libkea.1.4.6.dylib
+else
+    ln -s $PREFIX/lib/libkea.so.1.4.7 $PREFIX/lib/libkea.so.1.4.6
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: ec38751b3b555d3a26f0c7445f2d2cd9d7c3a3502237519a206a50cb58df56ec
 
 build:
-    number: 0
+    number: 1
     skip: True  # [win and py36]
     features:
         - vc9  # [win and py27]


### PR DESCRIPTION
Upgrading the build broke GDAL, this seems the easiest way to fix it. xref: https://github.com/conda-forge/gdal-feedstock/pull/156

Only seems to be a Unix problem.