### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: ec38751b3b555d3a26f0c7445f2d2cd9d7c3a3502237519a206a50cb58df56ec
 
 build:
-    number: 1
+    number: 2
     skip: True  # [win and py36]
     features:
         - vc9  # [win and py27]
@@ -22,10 +22,10 @@ requirements:
         - toolchain
         - python  # [win]
         - cmake
-        - hdf5 1.8.17|1.8.17.*
+        - hdf5 1.8.18|1.8.18.*
 
     run:
-        - hdf5 1.8.17|1.8.17.*
+        - hdf5 1.8.18|1.8.18.*
 
 about:
     home: http://kealib.org/


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71