### PR TITLE
Vc9 build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,10 +9,10 @@ environment:
     secure: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1
 
   matrix:
-    - CONFIG: win_c_compilervs2008cxx_compilervs2008
+    - CONFIG: win_c_compilervs2008cxx_compilervs2008hdf51.10.2
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_c_compilervs2015cxx_compilervs2015
+    - CONFIG: win_c_compilervs2015cxx_compilervs2015hdf51.10.4
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/win_c_compilervs2008cxx_compilervs2008hdf51.10.2.yaml
+++ b/.ci_support/win_c_compilervs2008cxx_compilervs2008hdf51.10.2.yaml
@@ -7,7 +7,8 @@ channel_targets:
 cxx_compiler:
 - vs2008
 hdf5:
-- 1.10.4
+- 1.10.2
 zip_keys:
 - - c_compiler
   - cxx_compiler
+  - hdf5

--- a/.ci_support/win_c_compilervs2008cxx_compilervs2008hdf51.10.2.yaml
+++ b/.ci_support/win_c_compilervs2008cxx_compilervs2008hdf51.10.2.yaml
@@ -1,3 +1,7 @@
+pin_run_as_build:
+  hdf5:
+    min_pin: x.x.x
+    max_pin: x.x.x
 c_compiler:
 - vs2008
 channel_sources:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015hdf51.10.4.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015hdf51.10.4.yaml
@@ -11,3 +11,4 @@ hdf5:
 zip_keys:
 - - c_compiler
   - cxx_compiler
+  - hdf5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b1bd2d6834d2fe09ba456fce77f7a9452b406dbe302f7ef1aabe924e45e6bb5e
 
 build:
-  number: 1001
+  number: 1002
   run_exports:
     - {{ pin_subpackage('kealib', max_pin='x.x') }}
 


### PR DESCRIPTION
@gillins is it possible to build this version of `kealib` with `hdf5 1.10.2` for `vc9`? `kealib` is the last missing piece in https://github.com/conda-forge/gdal-feedstock/pull/246